### PR TITLE
Search fix

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,9 +2,8 @@
 <addon id="plugin.video.sosac.ph" name="Sosáč" provider-name="L. Zoubek + jondas" version="1.2.3">
     <requires>
         <import addon="xbmc.python" version="2.1.0" />
-        <import addon="script.module.stream.resolver" version="1.6.35" />
+        <import addon="script.module.stream.resolver" version="1.6.38" />
         <import addon="script.common.plugin.cache" version="2.5.0" />
-        <import addon="script.module.beautifulsoup4" version="4.3.1"/>
     </requires>
     <extension library="default.py" point="xbmc.python.pluginsource" provides="video">
         <provides>video</provides>

--- a/resources/lib/sosac.py
+++ b/resources/lib/sosac.py
@@ -26,7 +26,6 @@ import urllib2
 import cookielib
 import xml.etree.ElementTree as ET
 import sys
-from bs4 import BeautifulSoup
 
 import util
 from provider import ContentProvider, cached, ResolveException
@@ -480,13 +479,9 @@ class SosacContentProvider(ContentProvider):
     def get_subs(self):
         return self.parent.get_subs()
 
-    @staticmethod
-    def parse_html(url):
-        return BeautifulSoup(util.request(url))
-
     def list_search(self, url):
         result = []
-        html_tree = self.parse_html(url)
+        html_tree = util.parse_html(url)
         for entry in html_tree.select('ul.content li'):
             item = self.video_item()
             entry.p.strong.extract()

--- a/resources/lib/sosac.py
+++ b/resources/lib/sosac.py
@@ -108,7 +108,7 @@ class SosacContentProvider(ContentProvider):
         if XML_LETTER in url:
             return True
         return False
-    
+
     @staticmethod
     def is_base_url(url):
         if url in [MOVIES_BASE_URL, TV_SHOWS_BASE_URL]:
@@ -189,7 +189,7 @@ class SosacContentProvider(ContentProvider):
 
         if self.has_tv_show_flag(url):
             return self.list_tv_show(self.remove_flags(url))
-        
+
         if self.is_xml_letter(url):
             print("xml letter")
             if "movie" in url:
@@ -200,12 +200,12 @@ class SosacContentProvider(ContentProvider):
     def list_xml_letter(self, url):
         result = []
         data = util.request(url)
-        print(data);
+        print(data)
         tree = ET.fromstring(data)
         titles = []
         num = 0
         turl = 'http://csfd.bbaron.sk/find.php'
-        #for film in tree.findall('film'):
+        # for film in tree.findall('film'):
         #    titles.append(film.findtext('nazeven').encode('utf-8'))
         #    num = num + 1
         #    if num > 5:
@@ -214,7 +214,7 @@ class SosacContentProvider(ContentProvider):
         #        print(stdata)
         #        num = 0
         #        titles = []
-        
+
         for film in tree.findall('film'):
             item = self.video_item()
             try:
@@ -222,7 +222,7 @@ class SosacContentProvider(ContentProvider):
                     title = film.findtext('nazevcs')
                 else:
                     title = film.findtext('nazeven')
-                item['title'] = '%s (%s)' % (title , film.findtext('rokvydani'))
+                item['title'] = '%s (%s)' % (title, film.findtext('rokvydani'))
                 item['name'] = item['title'].encode('utf-8')
                 item['img'] = film.findtext('obrazekmaly')
                 item['url'] = self.base_url + '/player/' + self.parent.make_name(


### PR DESCRIPTION
These changes use `parse_html()` from `util` library for HTML parsing and remove our own implementation of `parse_html()` together with dependency on BeautifulSoup4. Improved reliability and fixed #35 are expected results of merging.
