### PR TITLE
Zobrazeni CZ nazvu misto EN pri nastaveni Kodi-SK

### DIFF
--- a/resources/lib/sosac.py
+++ b/resources/lib/sosac.py
@@ -59,7 +59,7 @@ class SosacContentProvider(ContentProvider):
 
     def on_init(self):
         kodilang = self.lang or 'cs'
-        if kodilang == ISO_639_1_CZECH:
+        if kodilang == ISO_639_1_CZECH or kodilang == 'sk':
             self.ISO_639_1_CZECH = ISO_639_1_CZECH + '/'
         else:
             self.ISO_639_1_CZECH = ''


### PR DESCRIPTION
Zobrazeni filmovych nazvu v CZ pri nastavenem jazkyku KODI do SK.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kodi-czsk/plugin.video.sosac.ph/63)

<!-- Reviewable:end -->
