### PR TITLE
rewrite library to use JSON files

### DIFF
--- a/resources/lib/sosac.py
+++ b/resources/lib/sosac.py
@@ -54,6 +54,18 @@ IMAGE_MOVIE = IMAGE_URL + "75x109/movie-"
 IMAGE_SERIES = IMAGE_URL + "558x313/serial-"
 IMAGE_EPISODE = URL
 
+LIBRARY_MENU_ITEM_ADD = "[B][COLOR red]Add to library[/COLOR][/B]"
+LIBRARY_MENU_ITEM_ADD_ALL = "[B][COLOR red]Add all to library[/COLOR][/B]"
+LIBRARY_MENU_ITEM_REMOVE = "[B][COLOR red]Remove from subscription[/COLOR][/B]"
+LIBRARY_TYPE_VIDEO = "video"
+LIBRARY_TYPE_TVSHOW = "tvshow"
+LIBRARY_TYPE_ALL_VIDEOS = "all-videos"
+LIBRARY_TYPE_ALL_SHOWS = "all-shows"
+LIBRARY_ACTION_ADD = "add-to-library"
+LIBRARY_ACTION_ADD_ALL = "add-all-to-library"
+LIBRARY_ACTION_REMOVE_SUBSCRIPTION = "remove-subscription"
+LIBRARY_FLAG_IS_PRESENT = "[B][COLOR yellow]*[/COLOR][/B] "
+
 RATING = 'r'
 LANG = 'd'
 QUALITY = 'q'
@@ -66,7 +78,8 @@ class SosacContentProvider(ContentProvider):
     def __init__(self, username=None, password=None, filter=None, reverse_eps=False):
         ContentProvider.__init__(self, name='sosac.ph', base_url=MOVIES_BASE_URL, username=username,
                                  password=password, filter=filter)
-        opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookielib.LWPCookieJar()))
+        opener = urllib2.build_opener(
+            urllib2.HTTPCookieProcessor(cookielib.LWPCookieJar()))
         urllib2.install_opener(opener)
         self.reverse_eps = reverse_eps
 
@@ -82,25 +95,43 @@ class SosacContentProvider(ContentProvider):
 
     def categories(self):
         result = []
-        for title, url in [
-            ("Movies", URL + J_MOVIES_A_TO_Z_TYPE),
-            ("TV Shows", URL + J_TV_SHOWS_A_TO_Z_TYPE),
-            ("Movies - by Genres", URL + J_MOVIES_GENRE),
-            ("Movies - Most popular", URL + J_MOVIES_MOST_POPULAR),
-            ("TV Shows - Most popular", URL + J_TV_SHOWS_MOST_POPULAR),
-            ("Movies - Recently added", URL + J_MOVIES_RECENTLY_ADDED),
-            ("TV Shows - Recently added", URL + J_TV_SHOWS_RECENTLY_ADDED)]:
-            item = self.dir_item(title=title, url=url)
-#            if title == 'Movies' or title == 'TV Shows' or title == 'Movies - Recently added':
-#                item['menu'] = {"[B][COLOR red]Add all to library[/COLOR][/B]": {
-#                    'action': 'add-all-to-library', 'title': title}}
-            result.append(item)
+        item = self.dir_item(title="Movies", url=URL + J_MOVIES_A_TO_Z_TYPE)
+        item['menu'] = {LIBRARY_MENU_ITEM_ADD_ALL: {
+            'action': LIBRARY_ACTION_ADD_ALL, 'type': LIBRARY_TYPE_ALL_VIDEOS}}
+        result.append(item)
+
+        item = self.dir_item(title="TV Shows", url=URL +
+                             J_TV_SHOWS_A_TO_Z_TYPE)
+        item['menu'] = {LIBRARY_MENU_ITEM_ADD_ALL: {
+            'action': LIBRARY_ACTION_ADD_ALL, 'type': LIBRARY_TYPE_ALL_SHOWS}}
+        result.append(item)
+
+        item = self.dir_item(title="Movies - by Genres", url=URL +
+                             J_MOVIES_GENRE)
+        result.append(item)
+
+        item = self.dir_item(title="Movies - Most popular", url=URL +
+                             J_MOVIES_MOST_POPULAR)
+        result.append(item)
+
+        item = self.dir_item(title="TV Shows - Most popular", url=URL +
+                             J_TV_SHOWS_MOST_POPULAR)
+        result.append(item)
+
+        item = self.dir_item(title="Movies - Recently added", url=URL +
+                             J_MOVIES_RECENTLY_ADDED)
+        result.append(item)
+
+        item = self.dir_item(title="TV Shows - Recently added", url=URL +
+                             J_TV_SHOWS_RECENTLY_ADDED)
+        result.append(item)
+
         return result
 
     def search(self, keyword):
         if len(keyword) < 3 or len(keyword) > 100:
             return [self.dir_item(title="Search query must be between 3 and 100 characters long!", url="fail")]
-        return self.list_search(URL + J_SEARCH + urllib.quote_plus(keyword))
+        return self.list_videos(URL + J_SEARCH + urllib.quote_plus(keyword))
 
     def a_to_z(self, url):
         result = []
@@ -112,18 +143,11 @@ class SosacContentProvider(ContentProvider):
         return result
 
     @staticmethod
-    def remove_flag_from_url(url, flag):
-        return url.replace(flag, "", count=1)
-
-    @staticmethod
     def particular_letter(url):
         return "a-z/" in url
 
     def has_tv_show_flag(self, url):
         return TV_SHOW_FLAG in url
-
-    def remove_flags(self, url):
-        return url.replace(TV_SHOW_FLAG, "", 1)
 
     def list(self, url):
         util.info("Examining url " + url)
@@ -152,7 +176,7 @@ class SosacContentProvider(ContentProvider):
         data = util.request(url)
         json_list = json.loads(data)
         for key, value in json_list.iteritems():
-            item = self.dir_item(title=self.upper_first_letter(key))
+            item = self.dir_item(title=key.title())
             item['url'] = value
             result.append(item)
 
@@ -173,18 +197,29 @@ class SosacContentProvider(ContentProvider):
                 item['lang'] = video[LANG]
             if QUALITY in video:
                 item['quality'] = video[QUALITY]
+            item['menu'] = {LIBRARY_MENU_ITEM_ADD: {
+                'url': item['url'], 'type': LIBRARY_TYPE_VIDEO, 'action': LIBRARY_ACTION_ADD, 'name': self.get_library_video_name(video)}}
+
             result.append(item)
         return result
 
-    def list_series_letter(self, url):
+    def list_series_letter(self, url, load_subs=True):
         result = []
         data = util.request(url)
         json_list = json.loads(data)
+        subs = self.get_subscriptions() if load_subs else {}
         for serial in json_list:
             item = self.dir_item()
             item['title'] = self.get_localized_name(serial['n'])
             item['img'] = IMAGE_SERIES + serial['i']
             item['url'] = serial['l']
+            if item['url'] in subs:
+                item['title'] = LIBRARY_FLAG_IS_PRESENT + item['title']
+                item['menu'] = {LIBRARY_MENU_ITEM_REMOVE: {
+                    'url': item['url'], 'action': LIBRARY_ACTION_REMOVE_SUBSCRIPTION, 'name': self.get_library_video_name(serial)}}
+            else:
+                item['menu'] = {LIBRARY_MENU_ITEM_ADD: {
+                    'url': item['url'], 'type': LIBRARY_TYPE_TVSHOW, 'action': LIBRARY_ACTION_ADD, 'name': self.get_library_video_name(serial)}}
             result.append(item)
         return result
 
@@ -196,8 +231,10 @@ class SosacContentProvider(ContentProvider):
             for series_key, episode in series.iteritems():
                 for episode_key, video in episode.iteritems():
                     item = self.video_item()
-                    item['title'] = series_key + "x" + episode_key + " - " + video['n']
-                    item['img'] = IMAGE_EPISODE + video['i']
+                    item['title'] = series_key + "x" + \
+                        episode_key + " - " + video['n']
+                    if video['i'] is not None:
+                        item['img'] = IMAGE_EPISODE + video['i']
                     item['url'] = video['l'] if video['l'] else ""
                     result.append(item)
         if not self.reverse_eps:
@@ -216,11 +253,36 @@ class SosacContentProvider(ContentProvider):
             result.append(item)
         return result
 
+    def list_all_videos(self):
+        letters = self.load_json_list(URL + J_MOVIES_A_TO_Z_TYPE)
+        total = len(letters)
+
+        step = int(100 / len(letters))
+        for idx, letter in enumerate(letters):
+            for video in self.list_videos(letter['url']):
+                yield video
+            yield {'progress': step * (idx + 1)}
+
+    def list_all_tvshows(self):
+        letters = self.a_to_z(J_TV_SHOWS)
+        total = len(letters)
+
+        step = int(100 / len(letters))
+        for idx, letter in enumerate(letters):
+            for video in self.list_series_letter(letter['url'], False):
+                yield video
+            yield {'progress': step * (idx + 1)}
+
     def get_video_name(self, video):
         name = self.get_localized_name(video['n'])
         year = (" (" + video['y'] + ") ") if video['y'] else " "
         quality = ("- " + video[QUALITY].upper()) if video[QUALITY] else ""
         return name + year + quality
+
+    def get_library_video_name(self, video):
+        name = self.get_localized_name(video['n'])
+        year = (" (" + video['y'] + ") ") if video['y'] else " "
+        return (name + year).encode('utf-8')
 
     def get_episode_recently_name(self, episode):
         serial = self.get_localized_name(episode['t']) + ' '
@@ -229,40 +291,8 @@ class SosacContentProvider(ContentProvider):
         name = self.get_localized_name(episode['n'])
         return serial + series + number + name
 
-    def add_video_flag(self, items):
-        flagged_items = []
-        for item in items:
-            flagged_item = self.video_item()
-            flagged_item.update(item)
-            flagged_items.append(flagged_item)
-        return flagged_items
-
-    def add_directory_flag(self, items):
-        flagged_items = []
-        for item in items:
-            flagged_item = self.dir_item()
-            flagged_item.update(item)
-            flagged_items.append(flagged_item)
-        return flagged_items
-    
     def get_localized_name(self, names):
         return names[self.ISO_639_1_CZECH] if self.ISO_639_1_CZECH in names else names[ISO_639_1_CZECH]
-
-    @cached(ttl=24)
-    def get_data_cached(self, url):
-        return util.request(url)
-
-    def add_flag_to_url(self, item, flag):
-        item['url'] = flag + item['url']
-        return item
-
-    def add_url_flag_to_items(self, items, flag):
-        subs = self.get_subs()
-        for item in items:
-            if item['url'] in subs:
-                item['title'] = '[B][COLOR yellow]*[/COLOR][/B] ' + item['title']
-            self.add_flag_to_url(item, flag)
-        return items
 
     def _url(self, url):
         # DirtyFix nefunkcniho downloadu: Neznam kod tak se toho zkusenejsi chopte
@@ -271,18 +301,6 @@ class SosacContentProvider(ContentProvider):
             return url
         else:
             return self.base_url + "/" + url.lstrip('./')
-
-    def list_tv_shows_by_letter(self, url):
-        util.info("Getting shows by letter " + url)
-        shows = self.list_by_letter(url)
-        util.info("Resolved shows " + str(shows))
-        shows = self.add_directory_flag(shows)
-        return self.add_url_flag_to_items(shows, TV_SHOW_FLAG)
-
-    def list_movies_by_letter(self, url):
-        movies = self.list_by_letter(url)
-        util.info("Resolved movies " + str(movies))
-        return self.add_video_flag(movies)
 
     def resolve(self, item, captcha_cb=None, select_cb=None):
         data = item['url']
@@ -294,11 +312,5 @@ class SosacContentProvider(ContentProvider):
         elif len(result) > 1 and select_cb:
             return select_cb(result)
 
-    def get_subs(self):
+    def get_subscriptions(self):
         return self.parent.get_subs()
-
-    def list_search(self, url):
-        return self.list_videos(url)
-
-    def upper_first_letter(self, name):
-        return name[:1].upper() + name[1:]

--- a/resources/lib/sutils.py
+++ b/resources/lib/sutils.py
@@ -11,6 +11,7 @@ import time
 import string
 import datetime
 import urllib
+import sosac
 
 
 class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
@@ -19,7 +20,8 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
     subs = None
 
     def __init__(self, provider, settings, addon):
-        xbmcprovider.XBMCMultiResolverContentProvider.__init__(self, provider, settings, addon)
+        xbmcprovider.XBMCMultiResolverContentProvider.__init__(
+            self, provider, settings, addon)
         provider.parent = self
         self.dialog = xbmcgui.DialogProgress()
         try:
@@ -30,7 +32,8 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
             self.cache = StorageServer.StorageServer("Downloader")
 
     def make_name(self, text, lower=True):
-        text = self.normalize_filename(text, "-_.' %s%s" % (string.ascii_letters, string.digits))
+        text = self.normalize_filename(
+            text, "-_.' %s%s" % (string.ascii_letters, string.digits))
         word_re = re.compile(r'\b\w+\b')
         text = ''.join([c for c in text if (c.isalnum() or c == "'" or c ==
                                             '.' or c == '-' or c.isspace())]) if text else ''
@@ -75,7 +78,8 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
 
     def showNotification(self, title, message, time=1000):
         xbmcgui.Dialog().notification(self.encode(title), self.encode(message), time=time,
-                                      icon=xbmc.translatePath(self.addon_dir() + "/icon.png"),
+                                      icon=xbmc.translatePath(
+                                          self.addon_dir() + "/icon.png"),
                                       sound=False)
 
     def evalSchedules(self):
@@ -88,7 +92,7 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
                 if xbmc.abortRequested:
                     util.info("SOSAC Exiting")
                     return
-                if self.provider.is_tv_shows_url(url):
+                if sub['type'] == sosac.LIBRARY_TYPE_TVSHOW:
                     if self.scanRunning() or self.isPlaying():
                         self.cache.delete("subscription.last_run")
                         return
@@ -97,11 +101,13 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
                         next_check = sub['last_run'] + (refresh * 3600 * 24)
                         if next_check < time.time():
                             if not notified:
-                                self.showNotification('Subscription', 'Chcecking')
+                                self.showNotification(
+                                    'Subscription', 'Chcecking')
                                 notified = True
                             util.debug("SOSAC Refreshing " + url)
                             new_items |= self.run_custom({
-                                'action': 'add-to-library',
+                                'action': sosac.LIBRARY_ACTION_ADD,
+                                'type': sosac.LIBRARY_TYPE_TVSHOW,
                                 'update': True,
                                 'url': url,
                                 'name': sub['name'],
@@ -110,7 +116,8 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
                             self.sleep(3000)
                         else:
                             n = (next_check - time.time()) / 3600
-                            util.debug("SOSAC Skipping " + url + " , next check in %dh" % n)
+                            util.debug("SOSAC Skipping " + url +
+                                       " , next check in %dh" % n)
             if new_items:
                 xbmc.executebuiltin('UpdateLibrary(video)')
             notified = False
@@ -147,28 +154,32 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
         error = False
         if not 'refresh' in params:
             params['refresh'] = str(self.getSetting("refresh_time"))
-        sub = {'name': params['name'], 'refresh': params['refresh']}
+        sub = {'name': params['name'], 'refresh': params[
+            'refresh'], 'type': params['type']}
+
         sub['last_run'] = time.time()
         arg = {"play": params['url'], 'cp': 'sosac.ph', "title": sub['name']}
-        item_url = xbmcutil._create_plugin_url(arg, 'plugin://' + self.addon_id + '/')
+        item_url = xbmcutil._create_plugin_url(
+            arg, 'plugin://' + self.addon_id + '/')
         util.info("item: " + item_url + " | " + str(params))
         new_items = False
         # self.showNotification('Linking', params['name'])
 
-        if "movie" in params['url']:
+        if params['type'] == sosac.LIBRARY_TYPE_VIDEO:
+            # movies are not stored in subs database
             item_dir = self.getSetting('library-movies')
             (error, new_items) = self.add_item_to_library(
                 os.path.join(item_dir, self.normalize_filename(sub['name']),
                              self.normalize_filename(params['name'])) + '.strm', item_url)
-        else:
+        elif params['type'] == sosac.LIBRARY_TYPE_TVSHOW:
             if not ('notify' in params):
                 self.showNotification(sub['name'], 'Checking new content')
 
             subs = self.get_subs()
             item_dir = self.getSetting('library-tvshows')
 
-            if not params['url'] in subs.keys():
-                subs.update({params['url']: params['name']})
+            if not params['url'] in subs:
+                subs.update({params['url']: sub})
                 self.set_subs(subs)
                 # self.addon.setSetting('tvshows-subs', json.dumps(subs))
 
@@ -180,27 +191,25 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
                         params['name']), 'tvshow.nfo'),
                         'http://thetvdb.com/index.php?tab=series&id=' + tvid)
 
-            list = self.provider.list_tv_show(params['url'])
-            for itm in list:
-                nfo = re.search('[^\d+](?P<season>\d+)[^\d]+(?P<episode>\d+)',
+            episodes = self.provider.list_episodes(params['url'])
+            for itm in episodes:
+                nfo = re.search('^(?P<season>\d+)x(?P<episode>\d+)',
                                 itm['title'], re.IGNORECASE | re.DOTALL)
                 arg = {"play": itm['url'], 'cp': 'sosac.ph',
-                       "title": itm['epname']}
-                """
-                info = ''.join(('<episodedetails><season>', nfo.group('season'),
-                                '</season><episode>', nfo.group('episode'),
-                                '</episode></episodedetails>'))
-                """
-                item_url = xbmcutil._create_plugin_url(arg, 'plugin://' + self.addon_id + '/')
-                (err, new) = self.add_item_to_library(os.path.join(
-                    item_dir, self.normalize_filename(params['name']), 'Season ' +
-                    nfo.group('season'), "S" + nfo.group('season') + "E" + nfo.group('episode') +
-                    '.strm'), item_url)
+                       "title": itm['title']}
+                item_url = xbmcutil._create_plugin_url(
+                    arg, 'plugin://' + self.addon_id + '/')
+                dirname = "Season " + nfo.group('season')
+                epname = "S%02dE%02d.strm" % (
+                    int(nfo.group('season')), int(nfo.group('episode')))
+                filename = os.path.join(item_dir, self.normalize_filename(
+                    params['name']), dirname, epname)
+                (err, new) = self.add_item_to_library(filename, item_url)
                 error |= err
                 if new is True and not err:
                     new_items = True
         if not error and new_items and not ('update' in params) and not ('notify' in params):
-            self.showNotification(params['name'], 'New content')
+            self.showNotification(params['name'], 'Found new content')
             xbmc.executebuiltin('UpdateLibrary(video)')
         elif not error and not ('notify' in params):
             self.showNotification(params['name'], 'No new content')
@@ -209,32 +218,59 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
         return new_items
 
     def run_custom(self, params):
-        if 'action' in params.keys():
+        if 'action' in params:
             icon = os.path.join(self.addon.getAddonInfo('path'), 'icon.png')
-            if params['action'] == 'remove-subscription':
+            if params['action'] == sosac.LIBRARY_ACTION_REMOVE_SUBSCRIPTION:
                 subs = self.get_subs()
                 if params['url'] in subs.keys():
                     del subs[params['url']]
                     self.set_subs(subs)
-                    self.showNotification(params['name'], 'Removed from subscription')
+                    self.showNotification(
+                        params['name'], 'Removed from subscriptions')
                     xbmc.executebuiltin('Container.Refresh')
                 return False
 
-            if params['action'] == 'add-to-library':
+            if params['action'] == sosac.LIBRARY_ACTION_ADD:
                 if self.add_item(params):
                     xbmc.executebuiltin('Container.Refresh')
                     return True
                 return False
-            if params['action'] == 'add-all-to-library':
-                self.dialog.create('sosac', 'Add all to library')
+            if params['action'] == sosac.LIBRARY_ACTION_ADD_ALL:
+                self.dialog.create("Sosac", "Adding All Movies to library")
                 self.dialog.update(0)
-                if params['title'] == 'Movies':
-                    self.provider.library_movies_all_xml()
-                elif params['title'] == 'Movies - Recently added':
-                    self.provider.library_movie_recently_added_xml()
-                elif params['title'] == 'TV Shows':
-                    self.provider.library_tvshows_all_xml()
-                self.dialog.close()
+                if params['type'] == sosac.LIBRARY_TYPE_ALL_VIDEOS:
+                    self.dialog.create("Sosac", "Adding All Movies to library")
+                    self.dialog.update(0)
+                    videos = self.provider.list_all_videos()
+                    for video in videos:
+                        if self.dialog.iscanceled():
+                            return
+                        if 'progress' in video:
+                            self.dialog.update(video['progress'])
+                        else:
+                            item = video['menu'][sosac.LIBRARY_MENU_ITEM_ADD]
+                            item["update"] = True
+                            item["notify"] = True
+                            item["type"] = sosac.LIBRARY_TYPE_VIDEO
+                            self.add_item(item)
+                    self.dialog.close()
+                elif params['type'] == sosac.LIBRARY_TYPE_ALL_SHOWS:
+                    self.dialog.create(
+                        "Sosac", "Adding All TV Shows to library")
+                    self.dialog.update(0)
+                    shows = self.provider.list_all_tvshows()
+                    for show in shows:
+                        if self.dialog.iscanceled():
+                            return
+                        if 'progress' in show:
+                            self.dialog.update(show['progress'])
+                        else:
+                            item = show['menu'][sosac.LIBRARY_MENU_ITEM_ADD]
+                            item["update"] = True
+                            item["notify"] = True
+                            item["type"] = sosac.LIBRARY_TYPE_TVSHOW
+                            self.add_item(item)
+
                 xbmc.executebuiltin('UpdateLibrary(video)')
         return False
 
@@ -258,7 +294,8 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
                     file_desc.close()
                     new = True
                 except Exception, e:
-                    util.error('Failed to create .strm file: ' + item_path + " | " + str(e))
+                    util.error('Failed to create .strm file: ' +
+                               item_path + " | " + str(e))
                     error = True
         else:
             error = True
@@ -268,25 +305,19 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
     def get_subs(self):
         if self.subs is not None:
             return self.subs
-        data = self.cache.get("subscription")
+        data = self.cache.get("subscription-1")
         try:
             if data == '':
                 return {}
-            subs = eval(data)
-            for url, name in subs.iteritems():
-                if not isinstance(name, dict):
-                    subs[url] = {'name': name,
-                                 'refresh': '1', 'last_run': -1}
-            self.set_subs(subs)
-            self.subs = subs
+            self.subs = eval(data)
+            return self.subs
         except Exception, e:
             util.error(e)
-            subs = {}
-        return subs
+            return {}
 
     def set_subs(self, subs):
         self.subs = subs
-        self.cache.set("subscription", repr(subs))
+        self.cache.set("subscription-1", repr(subs))
 
     @staticmethod
     def encode(string):


### PR DESCRIPTION
Přepsán kód, který importuje do knihovny tak, aby využíval JSON soubory.
Funguje:

- přidání jednoho filmu
- přidání včech filmů
- přidání jednoho seriálu
- přidání všech seriálů
- označení seriálu obsažených v knihovně (žlutá hvězdička)
- odebrání seriálu z knihovny

Odebral jsem možnost přidat do knihovny "Recently Added Movies", myslím, že nemá moc smysl.

Při upgrade z předcházející verze se bude knihovna (označené seriály) jevit jako prázdná. 

`.strm` soubory vygenerované **verzí < 1.3.0 plugin už nepřehraje**. Uživatelé budou muset nejprve smazat původní `.strm` a pak přidat do knihovny obsah znovu. Mazání je nutné, protože se mohlo změnit pojmenování filmů/seriálů.

Je třeba otestovat jeslti nepadá automatická aktualizaci knihovny, seriál se refreshuje jednou za den