### PR TITLE
Vynucovanie ceskych nazvov

### DIFF
--- a/default.py
+++ b/default.py
@@ -37,6 +37,7 @@ settings = {'downloads': __set__('downloads'), 'quality': __set__(
 
 
 reverse_eps = __set__('order-episodes') == '0'
+force_czech = __set__('force-czech') == 'true'
 
 util.info("URL: " + sys.argv[2])
 params = util.params()
@@ -44,4 +45,5 @@ if params == {}:
     xbmcutil.init_usage_reporting(__scriptid__)
 
 util.info("Running sosac provider with params: " + str(params))
-XBMCSosac(SosacContentProvider(reverse_eps=reverse_eps), settings, __addon__).run(params)
+XBMCSosac(SosacContentProvider(reverse_eps=reverse_eps, force_czech=force_czech), settings,
+          __addon__).run(params)

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -39,4 +39,5 @@
     <string id="30105">Výchozí čas pro obnovu seriálu (dny)</string>
     <string id="30063">Vkládat titulky, jsou li k dispozici</string>
     <string id="31000">Data o použití jsou zaslána pouze v okamžiku, kdy spustíte přehrávání nebo stahování videa doplňkem.</string>
+    <string id="30070">Vynutit české názvy</string>
 </strings>

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -37,7 +37,7 @@
     <string id="30103">Obecné</string>
     <string id="30104">Služba knihovny</string>
     <string id="30105">Výchozí čas pro obnovu seriálu (dny)</string>
-    <string id="30063">Vkládat titulky, jsou li k dispozici</string>
+    <string id="30065">Vkládat titulky, jsou li k dispozici</string>
     <string id="31000">Data o použití jsou zaslána pouze v okamžiku, kdy spustíte přehrávání nebo stahování videa doplňkem.</string>
     <string id="30070">Vynutit české názvy</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -38,7 +38,7 @@
     <string id="30103">General</string>
     <string id="30104">Subscriptions</string>
     <string id="30105">Default show check time (days)</string>
-    <string id="30063">Load subtitles if available</string>
+    <string id="30065">Load subtitles if available</string>
     <string id="31000">Usage of plugin is tracked whenever you play or download video.</string>
     <string id="30070">Force Czech titles</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -40,4 +40,5 @@
     <string id="30105">Default show check time (days)</string>
     <string id="30063">Load subtitles if available</string>
     <string id="31000">Usage of plugin is tracked whenever you play or download video.</string>
+    <string id="30070">Force Czech titles</string>
 </strings>

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -39,4 +39,6 @@
 	<string id="30104">Služba knižnice</string>
 	<string id="30105">Štandardný čas pre obnovu seriálov (dni)</string>
 	<string id="31000">Údaje o použití sú zaslané iba v okamihu, keď spustíte prehrávanie alebo sťahovanie videa doplnkom.</string>
+    <string id="30065">Vkladať titulky</string>
+	<string id="30070">Vynutit české názvy</string>
 </strings>

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -39,6 +39,6 @@
 	<string id="30104">Služba knižnice</string>
 	<string id="30105">Štandardný čas pre obnovu seriálov (dni)</string>
 	<string id="31000">Údaje o použití sú zaslané iba v okamihu, keď spustíte prehrávanie alebo sťahovanie videa doplnkom.</string>
-    <string id="30065">Vkladať titulky</string>
+	<string id="30065">Vkladať titulky</string>
 	<string id="30070">Vynutit české názvy</string>
 </strings>

--- a/resources/lib/sosac.py
+++ b/resources/lib/sosac.py
@@ -84,16 +84,18 @@ class SosacContentProvider(ContentProvider):
     ISO_639_1_CZECH = None
     par = None
 
-    def __init__(self, username=None, password=None, filter=None, reverse_eps=False):
+    def __init__(self, username=None, password=None, filter=None, reverse_eps=False,
+                 force_czech=False):
         ContentProvider.__init__(self, name='sosac.ph', base_url=MOVIES_BASE_URL, username=username,
                                  password=password, filter=filter)
         opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookielib.LWPCookieJar()))
         urllib2.install_opener(opener)
         self.reverse_eps = reverse_eps
+        self.force_czech = force_czech
 
     def on_init(self):
         kodilang = self.lang or 'cs'
-        if kodilang == ISO_639_1_CZECH or kodilang == 'sk':
+        if kodilang == ISO_639_1_CZECH or kodilang == 'sk' or self.force_czech:
             self.ISO_639_1_CZECH = ISO_639_1_CZECH
         else:
             self.ISO_639_1_CZECH = 'en'

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,6 +6,7 @@
         <setting label="30057" id="order-episodes" type="enum" lvalues="30058|30059" default="0" />
         <setting label="30050" id="quality" type="enum" lvalues="30051|30052|30053|30054|30055|30056" default="0" />
         <setting label="30060" id="language" type="enum" lvalues="30061|30062|30063" default="0" />
+        <setting label="30070" id="force-czech" type="bool" default="false" />
         <setting label="30030" id="downloads" type="folder" default="" />
         <setting label="30032" id="download-notify" type="bool" default="true" />
         <setting label="30033" id="download-notify-every" type="enum" lvalues="30034|30035|30036" default="0" visible="eq(-1,true)" />

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,7 +2,7 @@
 <settings>
     <category label="30103">
         <setting label="30000" type="text" id="keep-searches" default="20" />
-        <setting label="30063" id="subs" type="bool" default="true" />
+        <setting label="30065" id="subs" type="bool" default="true" />
         <setting label="30057" id="order-episodes" type="enum" lvalues="30058|30059" default="0" />
         <setting label="30050" id="quality" type="enum" lvalues="30051|30052|30053|30054|30055|30056" default="0" />
         <setting label="30060" id="language" type="enum" lvalues="30061|30062|30063" default="0" />


### PR DESCRIPTION
Pridano nastaveni, ktere vynuti ceske nazvy filmu a serialu v pripade, ze kodi je v EN. Dale opravena chyba v lokalizaci ohledne nacitani titulku