### PR TITLE
Fix vypoctu casu pro start sluzby

### DIFF
--- a/resources/lib/sutils.py
+++ b/resources/lib/sutils.py
@@ -50,7 +50,7 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
     def service(self):
         util.info("SOSAC Service Started")
         try:
-            sleep_time = int(self.getSetting("start_sleep_time")) * 1000 * 60
+            sleep_time = int(self.getSetting("start_sleep_time")) * 60 * 60
         except:
             sleep_time = self.sleep_time
             pass


### PR DESCRIPTION
https://github.com/kodi-czsk/plugin.video.sosac.ph/issues/134 - **sleep_time** by mel byt v sekundach, takze prevod na hodiny by mel byt **hodnota\*60\*60** a ne **hodnota\*1000\*60**