### PR TITLE
Fix vypoctu casu pro start sluzby - oprava

### DIFF
--- a/resources/lib/sutils.py
+++ b/resources/lib/sutils.py
@@ -50,7 +50,7 @@ class XBMCSosac(xbmcprovider.XBMCMultiResolverContentProvider):
     def service(self):
         util.info("SOSAC Service Started")
         try:
-            sleep_time = int(self.getSetting("start_sleep_time")) * 60 * 60
+            sleep_time = int(self.getSetting("start_sleep_time")) * 1000 * 60 * 60
         except:
             sleep_time = self.sleep_time
             pass


### PR DESCRIPTION
Oprava pro #135
Python pouziva pro SLEEP sec, KODI ms.