### PR TITLE
Volba pro StreamujTV API proxy.

### DIFF
--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -45,4 +45,5 @@
     <string id="30110">Mimo ČR</string>
     <string id="31000">Data o použití jsou zaslána pouze v okamžiku, kdy spustíte přehrávání nebo stahování videa doplňkem.</string>
     <string id="30070">Vynutit české názvy</string>
+    <string id="30120">StreamujTV API Proxy</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -46,4 +46,5 @@
     <string id="30110">Other</string>
     <string id="31000">Usage of plugin is tracked whenever you play or download video.</string>
     <string id="30070">Force Czech titles</string>
+    <string id="30120">StreamujTV API Proxy</string>
 </strings>

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -48,4 +48,5 @@
     <string id="31000">Údaje o použití sú zaslané iba v okamihu, keď spustíte prehrávanie alebo sťahovanie videa doplnkom.</string>
     <string id="30065">Vkladať titulky</string>
     <string id="30070">Vynutit české názvy</string>
+    <string id="30120">StreamujTV API Proxy</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
     <category label="30103">
+        <setting label="30120" id="streamujtv_api_proxy" type="text" default="" />
         <setting label="30106" id="streamujtv_user" type="text" default="" />
         <setting label="30107" id="streamujtv_pass" type="text" default="" option="hidden" />
         <setting label="30108" id="streamujtv_location" type="enum" lvalues="30061|30109|30110" default="0" />


### PR DESCRIPTION
Prazdne policko tam necha tu co tam byla, vlastni hodnota umoznuje
ruzna kreativni reseni. Volbu si taha streamresolver z getSetting, protoze neexistuje normalni cesta jak to tam dostat.